### PR TITLE
Migrated to Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk11
 cache:
   directories:
   - "$HOME/.m2"

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,11 @@
     <jsr305.version>2.0.1</jsr305.version>
     <junit.version>4.11</junit.version>
     <mockito.version>3.1.0</mockito.version>
+    <hamcrest.version>1.3</hamcrest.version>
+    <maven.dependency.analyzer.version>1.11.1</maven.dependency.analyzer.version>
     <slf4j.version>1.7.2</slf4j.version>
+
+    <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
 
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -159,6 +163,12 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -190,7 +200,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>${maven.surefire.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -207,6 +217,17 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-analyzer</artifactId>
+            <version>${maven.dependency.analyzer.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.groupon.api</groupId>
     <artifactId>api-parent-pom</artifactId>
-    <version>1.1.1</version>
+    <version>2.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -163,7 +163,6 @@
 
   <build>
     <plugins>
-      <!-- Enable Inherited Plugins -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -179,7 +178,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -203,9 +201,12 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,11 @@
     <!--Dependency versions-->
     <jsr305.version>2.0.1</jsr305.version>
     <junit.version>4.11</junit.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>3.1.0</mockito.version>
     <slf4j.version>1.7.2</slf4j.version>
+
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
 
     <!--Coverage Settings-->
     <jacoco.check.line.coverage>0.8</jacoco.check.line.coverage>
@@ -143,7 +146,6 @@
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>
     </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -153,7 +155,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
@@ -177,6 +179,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -189,6 +192,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -199,12 +203,9 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/groupon/promise/PromiseCountdownHandler.java
+++ b/src/main/java/com/groupon/promise/PromiseCountdownHandler.java
@@ -39,7 +39,7 @@ class PromiseCountdownHandler {
     private PromiseHandler<Throwable> handleFailure;
     private List<Throwable> failures = new ArrayList<>();
 
-    public PromiseCountdownHandler(AtomicInteger count, PromiseHandler<Void> handleSuccess, PromiseHandler<Throwable> handleFailure) {
+    PromiseCountdownHandler(AtomicInteger count, PromiseHandler<Void> handleSuccess, PromiseHandler<Throwable> handleFailure) {
         latch = count;
         this.handleSuccess = handleSuccess;
         this.handleFailure = handleFailure;

--- a/src/main/java/com/groupon/promise/PromiseFunctionKey.java
+++ b/src/main/java/com/groupon/promise/PromiseFunctionKey.java
@@ -28,7 +28,7 @@ class PromiseFunctionKey<T> {
     private ComparablePromiseFunction promiseFunction;
     private T parameter;
 
-    public PromiseFunctionKey(@Nonnull ComparablePromiseFunction promiseFunction, T parameter) {
+    PromiseFunctionKey(@Nonnull ComparablePromiseFunction promiseFunction, T parameter) {
         this.promiseFunction = promiseFunction;
         this.parameter = parameter;
     }

--- a/src/main/java/com/groupon/promise/PromiseListImpl.java
+++ b/src/main/java/com/groupon/promise/PromiseListImpl.java
@@ -243,7 +243,7 @@ public class PromiseListImpl<T> extends PromiseImpl<Collection<T>> implements Pr
         private final PromiseCountdownHandler countdownHandler;
         private final PromiseImpl<T> childPromise;
 
-        public ConcurrencyLimitHandler(ConcurrentLinkedQueue<T> queueList, PromiseCountdownHandler countdownHandler,
+        ConcurrencyLimitHandler(ConcurrentLinkedQueue<T> queueList, PromiseCountdownHandler countdownHandler,
                                        PromiseImpl<T> childPromise) {
             this.queueList = queueList;
             this.countdownHandler = countdownHandler;

--- a/src/test/java/com/groupon/promise/PromiseCountdownHandlerTest.java
+++ b/src/test/java/com/groupon/promise/PromiseCountdownHandlerTest.java
@@ -17,7 +17,7 @@ package com.groupon.promise;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/groupon/promise/PromiseImplTest.java
+++ b/src/test/java/com/groupon/promise/PromiseImplTest.java
@@ -20,12 +20,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -537,7 +536,7 @@ public class PromiseImplTest {
 
         verify(onFulfilled, times(1)).handle(input);
         verifyNoMoreInteractions(onFulfilled);
-        verifyZeroInteractions(onFulfilledReversed);
+        verifyNoMoreInteractions(onFulfilledReversed);
     }
 
     @Test
@@ -729,7 +728,7 @@ public class PromiseImplTest {
         assertFalse(then.pending());
         assertTrue(then.fulfilled());
         assertFalse(then.rejected());
-        assertEquals(new Integer(1), then.value());
+        assertEquals(Integer.valueOf(1), then.value());
         assertNull(then.reason());
 
         assertFalse(nestedThen.pending());

--- a/src/test/java/com/groupon/promise/function/FulfillPromiseFunctionTest.java
+++ b/src/test/java/com/groupon/promise/function/FulfillPromiseFunctionTest.java
@@ -34,7 +34,7 @@ import com.groupon.promise.PromiseImpl;
 public class FulfillPromiseFunctionTest {
     private Promise<Integer> promise;
 
-    private Integer promiseVal = new Integer(200);
+    private Integer promiseVal = Integer.valueOf(200);
 
     @Before
     public void setUp() {

--- a/src/test/java/com/groupon/promise/function/FulfilledValueFunctionTest.java
+++ b/src/test/java/com/groupon/promise/function/FulfilledValueFunctionTest.java
@@ -40,7 +40,7 @@ public class FulfilledValueFunctionTest {
     @Mock
     private Promise<Integer> promise;
 
-    private Integer promiseVal = new Integer(200);
+    private Integer promiseVal = Integer.valueOf(200);
 
     @Before
     public void setUp() {


### PR DESCRIPTION
# Related JIRA Ticket
https://jira.groupondev.com/browse/GAPI-16613
# Motivation and Context
This library is a dependency of Lazlo so it is being moved to Java 11 as part of the Lazlo migration to Java 11.
# Changes

* Redefine compiler source and target to 11.
* Upgrade parent pom to 2.1.1
    * Has updated versions for plugins and new plugins we need such as spotbugs.
* Update mockito to 3.1.0.
    * https://github.com/mockito/mockito/issues/1325 
    * Use mockito-core instead of mockito-all.
    * Matchers is deprecated. Import org.mockito.Mockito.any instead.
        * https://www.javadoc.io/static/org.mockito/mockito-core/2.21.0/org/mockito/Matchers.html 
    * verifyZeroInteractions is deprecated. Use verifyNoMoreInteractions instead.
        * https://github.com/nhaarman/mockito-kotlin/issues/383 
* Update maven-javadoc-plugin to 3.0.1.
* Update maven-surefire-plugin to 3.0.0-M5.
    * https://maven.apache.org/surefire/maven-surefire-plugin/ (JDK 11 support added in 3.0.0-M3).
* Replace findbugs with spotbugs.
    * Findbugs is not supported for JDK 9+.
    * https://stackoverflow.com/questions/22028918/findbugs-noclassesfoundtoanalyze-exception
* Integer constructor is deprecated. Use Integer.valueOf instead.